### PR TITLE
Make gradle work again (except publishing, and this is a wontfix)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,8 +61,8 @@ subprojects {
     centralPortal {
         name = project.name
 
-        username = project.findProperty("sonatypeUsername") as String
-        password = project.findProperty("sonatypePassword") as String
+        username = project.findProperty("sonatypeUsername") as? String
+        password = project.findProperty("sonatypePassword") as? String
 
         pom {
             name.set("SimpleCloud controller")


### PR DESCRIPTION
This readds the possibility to build locally and use gradle in general without deleting the publication definitions. If you want to build locally however, you have to remove all signing definitions and sonatype imports. Sadly there is no workaround, so this is a wontfix.