### PR TITLE
fix: groups are not being deleted anymore

### DIFF
--- a/controller-runtime/src/main/kotlin/app/simplecloud/controller/runtime/YamlDirectoryRepository.kt
+++ b/controller-runtime/src/main/kotlin/app/simplecloud/controller/runtime/YamlDirectoryRepository.kt
@@ -140,7 +140,6 @@ abstract class YamlDirectoryRepository<E, I>(
                             if (entity != null) {
                                 watcherEvents.onDelete(entity)
                             }
-                            deleteFile(resolvedPath.toFile())
                         }
                     }
                 }

--- a/controller-runtime/src/main/kotlin/app/simplecloud/controller/runtime/server/ServerRepository.kt
+++ b/controller-runtime/src/main/kotlin/app/simplecloud/controller/runtime/server/ServerRepository.kt
@@ -22,13 +22,12 @@ class ServerRepository(
 ) : LoadableRepository<Server, String> {
 
     override suspend fun find(identifier: String): Server? {
-       return database.context.selectFrom(CLOUD_SERVERS)
+        return database.context.selectFrom(CLOUD_SERVERS)
             .where(CLOUD_SERVERS.UNIQUE_ID.eq(identifier))
             .limit(1)
             .awaitFirstOrNull()
             ?.let { record -> mapCloudServersRecordToServer(record) }
     }
-
 
     suspend fun findServerByNumerical(group: String, id: Int): Server? {
         return database.context.selectFrom(CLOUD_SERVERS)
@@ -121,7 +120,6 @@ class ServerRepository(
         }
     }
 
-    @Synchronized
     override fun save(element: Server) {
         numericalIdRepository.saveNumericalId(element.group, element.numericalId)
 

--- a/controller-runtime/src/main/kotlin/app/simplecloud/controller/runtime/server/ServerService.kt
+++ b/controller-runtime/src/main/kotlin/app/simplecloud/controller/runtime/server/ServerService.kt
@@ -60,7 +60,7 @@ class ServerService(
             return stopServer(server.toDefinition(), request.stopCause)
         } catch (e: Exception) {
             throw StatusException(
-                Status.INTERNAL.withDescription("Error occured whilest cleaning up stopped server: ").withCause(e)
+                Status.INTERNAL.withDescription("Error occurred whilst cleaning up stopped server: ").withCause(e)
             )
         }
     }
@@ -216,7 +216,9 @@ class ServerService(
                 startedServers.add(server)
             }
         } catch (e: Exception) {
-            throw StatusException(Status.INTERNAL.withDescription("Error whilst starting multiple servers").withCause(e))
+            throw StatusException(
+                Status.INTERNAL.withDescription("Error whilst starting multiple servers").withCause(e)
+            )
         }
 
         return StartMultipleServerResponse.newBuilder()
@@ -245,7 +247,6 @@ class ServerService(
         val server = buildServer(group, numericalId)
         serverRepository.save(server)
         val stub = host.stub ?: throw StatusException(Status.INTERNAL.withDescription("Server host has no stub"))
-        serverRepository.save(server)
         try {
             val result = stub.startServer(
                 ServerHostStartServerRequest.newBuilder()
@@ -263,7 +264,7 @@ class ServerService(
         }
     }
 
-    private suspend fun publishServerStartEvents(server: ServerDefinition, startCause: ServerStartCause) {
+    private fun publishServerStartEvents(server: ServerDefinition, startCause: ServerStartCause) {
         pubSubClient.publish(
             "event", ServerStartEvent.newBuilder()
                 .setServer(server)
@@ -380,7 +381,7 @@ class ServerService(
 
         try {
             timeout?.let {
-                group.timeout = GroupTimeout(it);
+                group.timeout = GroupTimeout(it)
             }
 
             groupServers.forEach { server ->


### PR DESCRIPTION
The issue where groups were being deleted randomly has been resolved. This behavior only occurred on Windows. Additionally, there's no need to call deleteFile inside the ENTRY_DELETE trigger, as this event is only triggered once a file deletion has already been detected by the system. Therefore, attempting to delete the file again within the trigger is unnecessary and redundant.